### PR TITLE
feat: add i18n support for hero and cta

### DIFF
--- a/src/lib/components/DeviceHero.svelte
+++ b/src/lib/components/DeviceHero.svelte
@@ -1,5 +1,6 @@
 <script>
-	import { Shield, Zap, Smartphone, Wifi, ChevronRight, Play } from 'lucide-svelte';
+        import { Shield, Zap, Smartphone, Wifi, ChevronRight, Play } from 'lucide-svelte';
+        import { t } from '$lib/utils/translations.js';
 </script>
 
 <section class="relative py-20 overflow-hidden">
@@ -18,23 +19,22 @@
 				<div
 					class="inline-flex items-center px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full text-sm font-medium mb-6"
 				>
-					<Shield class="w-4 h-4 mr-2 text-green-400" />
-					Privacy-First AI Assistant
+                                        <Shield class="w-4 h-4 mr-2 text-green-400" />
+                                        {t('home.hero.tagline')}
 				</div>
 
 				<h1 class="text-5xl md:text-6xl font-bold mb-6 leading-tight">
-					Arvify
-					<span
-						class="block text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-emerald-400"
-					>
-						Hybrid Intelligence
-					</span>
+                                                Arvify
+                                                <span
+                                                        class="block text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-emerald-400"
+                                                >
+                                                        {t('home.hero.highlight')}
+                                                </span>
 				</h1>
 
-				<p class="text-xl text-gray-300 mb-8 leading-relaxed">
-					Il primo dispositivo AI ibrido che combina la potenza del cloud con la privacy del locale.
-					Raspberry Pi 5 con Ollama integrato, controllato dalla tua app mobile.
-				</p>
+                                <p class="text-xl text-gray-300 mb-8 leading-relaxed">
+                                        {t('home.hero.description')}
+                                </p>
 
 				<!-- Key Features -->
 				<div class="space-y-4 mb-8">
@@ -42,19 +42,19 @@
 						<div class="w-8 h-8 bg-blue-500/20 rounded-lg flex items-center justify-center">
 							<Zap class="w-4 h-4 text-blue-400" />
 						</div>
-						<span class="text-gray-200">Elaborazione locale per massima privacy</span>
+                                                <span class="text-gray-200">{t('home.hero.features.localProcessing')}</span>
 					</div>
 					<div class="flex items-center space-x-3">
 						<div class="w-8 h-8 bg-emerald-500/20 rounded-lg flex items-center justify-center">
 							<Wifi class="w-4 h-4 text-emerald-400" />
 						</div>
-						<span class="text-gray-200">Cloud ibrido quando serve potenza extra</span>
+                                                <span class="text-gray-200">{t('home.hero.features.hybridCloud')}</span>
 					</div>
 					<div class="flex items-center space-x-3">
 						<div class="w-8 h-8 bg-purple-500/20 rounded-lg flex items-center justify-center">
 							<Smartphone class="w-4 h-4 text-purple-400" />
 						</div>
-						<span class="text-gray-200">Controllo totale via app mobile</span>
+                                                <span class="text-gray-200">{t('home.hero.features.mobileControl')}</span>
 					</div>
 				</div>
 
@@ -63,24 +63,24 @@
 					<button
 						class="btn-primary px-8 py-4 text-lg inline-flex items-center space-x-2 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 shadow-lg hover:shadow-xl transform hover:scale-105 transition-all"
 					>
-						<span>Ordina Ora</span>
+                                                <span>{t('home.hero.cta.order')}</span>
 						<ChevronRight class="w-5 h-5" />
 					</button>
 
 					<button
 						class="inline-flex items-center space-x-2 px-6 py-4 text-lg text-white border-2 border-white/20 rounded-xl hover:bg-white/10 transition-all"
 					>
-						<Play class="w-5 h-5" />
-						<span>Guarda Demo</span>
+                                                <Play class="w-5 h-5" />
+                                                <span>{t('home.hero.cta.demo')}</span>
 					</button>
 				</div>
 
 				<!-- Pricing Preview -->
 				<div class="mt-8 pt-8 border-t border-white/10">
 					<div class="flex items-center space-x-4">
-						<span class="text-gray-400">A partire da</span>
-						<span class="text-3xl font-bold text-white">€299</span>
-						<span class="text-gray-400">IVA inclusa</span>
+                                                <span class="text-gray-400">{t('home.hero.pricing.startingFrom')}</span>
+                                                <span class="text-3xl font-bold text-white">€299</span>
+                                                <span class="text-gray-400">{t('home.hero.pricing.vat')}</span>
 					</div>
 				</div>
 			</div>

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -1,14 +1,47 @@
 {
-	"nav": {
-		"mcpServers": "MCP Servers",
-		"pricing": "Pricing",
-		"login": "Login",
-		"home": "← Back to Home",
-		"language": "Language",
-		"cta": {
-			"from": "Starting at €299",
-			"orderNow": "Order Now",
-			"choosePlan": "Choose Plan"
-		}
-	}
+        "nav": {
+                "mcpServers": "MCP Servers",
+                "pricing": "Pricing",
+                "login": "Login",
+                "home": "← Back to Home",
+                "language": "Language",
+                "cta": {
+                        "from": "Starting at €299",
+                        "orderNow": "Order Now",
+                        "choosePlan": "Choose Plan"
+                }
+        },
+        "home": {
+                "hero": {
+                        "tagline": "Privacy-First AI Assistant",
+                        "highlight": "Hybrid Intelligence",
+                        "description": "The first hybrid AI device that combines cloud power with local privacy. Raspberry Pi 5 with built-in Ollama, controlled from your mobile app.",
+                        "features": {
+                                "localProcessing": "Local processing for maximum privacy",
+                                "hybridCloud": "Hybrid cloud when extra power is needed",
+                                "mobileControl": "Total control via mobile app"
+                        },
+                        "cta": {
+                                "order": "Order Now",
+                                "demo": "Watch Demo"
+                        },
+                        "pricing": {
+                                "startingFrom": "Starting from",
+                                "vat": "VAT included"
+                        }
+                },
+                "cta": {
+                        "headline": "Ready for the Future of AI?",
+                        "description": "Join thousands of users who already chose Arvify for a truly private and powerful AI experience.",
+                        "buttons": {
+                                "plans": "See All Plans",
+                                "mcp": "Explore MCP Servers"
+                        },
+                        "trust": {
+                                "garanzia": "30-day guarantee",
+                                "spedizione": "Free shipping",
+                                "madeInItaly": "Made in Italy"
+                        }
+                }
+        }
 }

--- a/src/lib/i18n/es.json
+++ b/src/lib/i18n/es.json
@@ -1,14 +1,47 @@
 {
-	"nav": {
-		"mcpServers": "Servidores MCP",
-		"pricing": "Precios",
-		"login": "Iniciar sesión",
-		"home": "← Volver al Inicio",
-		"language": "Idioma",
-		"cta": {
-			"from": "Desde €299",
-			"orderNow": "Ordenar Ahora",
-			"choosePlan": "Elegir Plan"
-		}
-	}
+        "nav": {
+                "mcpServers": "Servidores MCP",
+                "pricing": "Precios",
+                "login": "Iniciar sesión",
+                "home": "← Volver al Inicio",
+                "language": "Idioma",
+                "cta": {
+                        "from": "Desde €299",
+                        "orderNow": "Ordenar Ahora",
+                        "choosePlan": "Elegir Plan"
+                }
+        },
+        "home": {
+                "hero": {
+                        "tagline": "Asistente de IA centrado en la privacidad",
+                        "highlight": "Inteligencia Híbrida",
+                        "description": "El primer dispositivo de IA híbrido que combina la potencia de la nube con la privacidad local. Raspberry Pi 5 con Ollama integrado, controlado desde tu app móvil.",
+                        "features": {
+                                "localProcessing": "Procesamiento local para máxima privacidad",
+                                "hybridCloud": "Nube híbrida cuando se necesita potencia extra",
+                                "mobileControl": "Control total vía app móvil"
+                        },
+                        "cta": {
+                                "order": "Ordenar Ahora",
+                                "demo": "Ver Demo"
+                        },
+                        "pricing": {
+                                "startingFrom": "Desde",
+                                "vat": "IVA incluida"
+                        }
+                },
+                "cta": {
+                        "headline": "¿Listo para el Futuro de la IA?",
+                        "description": "Únete a miles de usuarios que ya eligieron Arvify para una experiencia de IA realmente privada y potente.",
+                        "buttons": {
+                                "plans": "Ver Todos los Planes",
+                                "mcp": "Explorar Servidores MCP"
+                        },
+                        "trust": {
+                                "garanzia": "Garantía de 30 días",
+                                "spedizione": "Envío gratis",
+                                "madeInItaly": "Hecho en Italia"
+                        }
+                }
+        }
 }

--- a/src/lib/i18n/it.json
+++ b/src/lib/i18n/it.json
@@ -1,14 +1,47 @@
 {
-	"nav": {
-		"mcpServers": "MCP Servers",
-		"pricing": "Prezzi",
-		"login": "Login",
-		"home": "← Torna alla Home",
-		"language": "Lingua",
-		"cta": {
-			"from": "A partire da €299",
-			"orderNow": "Ordina Ora",
-			"choosePlan": "Scegli Piano"
-		}
-	}
+        "nav": {
+                "mcpServers": "MCP Servers",
+                "pricing": "Prezzi",
+                "login": "Login",
+                "home": "← Torna alla Home",
+                "language": "Lingua",
+                "cta": {
+                        "from": "A partire da €299",
+                        "orderNow": "Ordina Ora",
+                        "choosePlan": "Scegli Piano"
+                }
+        },
+        "home": {
+                "hero": {
+                        "tagline": "Assistente AI Privacy-First",
+                        "highlight": "Intelligenza Ibrida",
+                        "description": "Il primo dispositivo AI ibrido che combina la potenza del cloud con la privacy del locale. Raspberry Pi 5 con Ollama integrato, controllato dalla tua app mobile.",
+                        "features": {
+                                "localProcessing": "Elaborazione locale per massima privacy",
+                                "hybridCloud": "Cloud ibrido quando serve potenza extra",
+                                "mobileControl": "Controllo totale via app mobile"
+                        },
+                        "cta": {
+                                "order": "Ordina Ora",
+                                "demo": "Guarda Demo"
+                        },
+                        "pricing": {
+                                "startingFrom": "A partire da",
+                                "vat": "IVA inclusa"
+                        }
+                },
+                "cta": {
+                        "headline": "Pronto per il Futuro dell'AI?",
+                        "description": "Unisciti a migliaia di utenti che hanno già scelto Arvify per un'esperienza AI davvero privata e potente.",
+                        "buttons": {
+                                "plans": "Vedi Tutti i Piani",
+                                "mcp": "Esplora MCP Servers"
+                        },
+                        "trust": {
+                                "garanzia": "30 giorni garanzia",
+                                "spedizione": "Spedizione gratuita",
+                                "madeInItaly": "Made in Italy"
+                        }
+                }
+        }
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,10 +3,11 @@
 	import DeviceAdvantages from '$lib/components/DeviceAdvantages.svelte';
 	import TechSpecs from '$lib/components/TechSpecs.svelte';
 	import HowItWorks from '$lib/components/HowItWorks.svelte';
-	import DeviceFooter from '$lib/components/DeviceFooter.svelte';
-	import Navigation from '$lib/components/Navigation.svelte';
-	import { Shield } from 'lucide-svelte';
-	import { onMount } from 'svelte';
+        import DeviceFooter from '$lib/components/DeviceFooter.svelte';
+        import Navigation from '$lib/components/Navigation.svelte';
+        import { Shield } from 'lucide-svelte';
+        import { onMount } from 'svelte';
+        import { t } from '$lib/utils/translations.js';
 
 	let isLoaded = $state(false);
 
@@ -52,24 +53,23 @@
 	<!-- Call to Action Section -->
 	<section class="py-20 bg-gradient-to-r from-blue-600 to-emerald-600">
 		<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-			<h2 class="text-4xl md:text-5xl font-bold text-white mb-6">Pronto per il Futuro dell'AI?</h2>
-			<p class="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
-				Unisciti a migliaia di utenti che hanno già scelto Arvify per un'esperienza AI davvero
-				privata e potente.
-			</p>
+                        <h2 class="text-4xl md:text-5xl font-bold text-white mb-6">{t('home.cta.headline')}</h2>
+                        <p class="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
+                                {t('home.cta.description')}
+                        </p>
 
 			<div class="flex flex-col sm:flex-row gap-4 justify-center items-center">
 				<a
 					href="/pricing"
 					class="bg-white text-blue-600 hover:bg-gray-100 px-8 py-4 rounded-xl font-semibold text-lg transition-all transform hover:scale-105 shadow-lg"
 				>
-					Vedi Tutti i Piani
+                                        {t('home.cta.buttons.plans')}
 				</a>
 				<a
 					href="/mcp-servers"
 					class="text-white border-2 border-white/30 hover:bg-white/10 px-8 py-4 rounded-xl font-semibold text-lg transition-all"
 				>
-					Esplora MCP Servers
+                                        {t('home.cta.buttons.mcp')}
 				</a>
 			</div>
 
@@ -77,15 +77,15 @@
 			<div class="mt-12 flex flex-wrap justify-center items-center gap-8 text-blue-100">
 				<div class="flex items-center space-x-2">
 					<Shield class="w-5 h-5" />
-					<span>30 giorni garanzia</span>
+                                        <span>{t('home.cta.trust.garanzia')}</span>
 				</div>
 				<div class="flex items-center space-x-2">
 					<span class="text-lg">🚚</span>
-					<span>Spedizione gratuita</span>
+                                        <span>{t('home.cta.trust.spedizione')}</span>
 				</div>
 				<div class="flex items-center space-x-2">
 					<span class="text-lg">🇮🇹</span>
-					<span>Made in Italy</span>
+                                        <span>{t('home.cta.trust.madeInItaly')}</span>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary
- add multilingual strings for hero and CTA sections
- replace hardcoded text with translation helper

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/esbuild)*

------
https://chatgpt.com/codex/tasks/task_e_68a05f850a2883308a6aefb593ed3190